### PR TITLE
Deps: Adding oras-go as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "deps/encpasssh"]
 	path = deps/encpasssh
 	url = https://github.com/juliusl/encpass.sh.git
+[submodule "deps/oras-go"]
+	path = deps/oras-go
+	url = git@github.com:juliusl/oras-go.git
+	branch = juliusl/remotes-with-login


### PR DESCRIPTION
This repo will take a dependency on oras-go via submodule. This comes from cpp style "Live at HEAD". 